### PR TITLE
Changes to work with Rails 7

### DIFF
--- a/active_storage_db.gemspec
+++ b/active_storage_db.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  spec.add_dependency 'activestorage', '~> 6.0'
-  spec.add_dependency 'rails', '~> 6.0'
+  spec.add_dependency 'activestorage', '~> 7.0'
+  spec.add_dependency 'rails', '~> 7.0'
 
   spec.add_development_dependency 'factory_bot_rails', '~> 6.1'
 end

--- a/lib/active_storage/service/db_service.rb
+++ b/lib/active_storage/service/db_service.rb
@@ -112,7 +112,12 @@ module ActiveStorage
     private
 
     def current_host
-      ActiveStorage::Current.host
+      host = ActiveStorage::Current.url_options[:host]
+      port = ActiveStorage::Current.url_options[:port]
+      protocol = ActiveStorage::Current.url_options[:protocol]
+
+      url = URI.parse("#{protocol}://#{host}:#{port}").to_s
+      return URI.encode(url)
     end
 
     def ensure_integrity_of(key, checksum)


### PR DESCRIPTION
When trying to use it directly with Rails 7, the redirect URL stopped working because the full host URI was missing.

I adapted the current_host method to return the url used as before and keep the previous code intact