### PR TITLE
Fix current url_options without a port (default port)

### DIFF
--- a/lib/active_storage/service/db_service_rails70.rb
+++ b/lib/active_storage/service/db_service_rails70.rb
@@ -20,7 +20,8 @@ module ActiveStorage
     def current_host
       opts = url_options || {}
       url = "#{opts[:protocol]}#{opts[:host]}"
-      url + ":#{opts[:port]}" if opts[:port]
+      url += ":#{opts[:port]}" if opts[:port]
+      url
     end
 
     def private_url(key, expires_in:, filename:, content_type:, disposition:, **)

--- a/spec/service/active_storage/service/db_service_spec.rb
+++ b/spec/service/active_storage/service/db_service_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe ActiveStorage::Service::DBService do
       url = service.url('some_key', filename: filename, disposition: :inline, content_type: 'text/plain', expires_in: nil)
       expect(url).to match %r{#{host}/active_storage_db/files/}
     end
+
+    context 'without port' do
+      let(:url_options) do
+        {
+          protocol: 'https://',
+          host: 'test.example.com',
+        }
+      end
+
+      it 'returns a public URL' do
+        filename = ActiveStorage::Filename.new('some_filename')
+        service = ActiveStorage::Service.configure(:db, config)
+        url = service.url('some_key', filename: filename, disposition: :inline, content_type: 'text/plain', expires_in: nil)
+        expect(url).to match %r{https://test.example.com/active_storage_db/files/}
+      end
+    end
   end
 
   if Rails::VERSION::MAJOR >= 7


### PR DESCRIPTION
If no port is specified on `ActiveStorage::Current.url_options` `current_host` would return `nil` instead of `"http://example.com"`