### PR TITLE
Handle a failing spec related to the Bullet offense

### DIFF
--- a/spec/integration/attachments_spec.rb
+++ b/spec/integration/attachments_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe 'Attachments' do
     end
     let(:test_post) { Post.new(title: 'A test post', some_file: uploaded_file) }
 
+    around do |example|
+      # NOTE: touch_attachment_records trigger an extra includes on ActiveStorage::Attachment
+      if ActiveStorage.respond_to?(:touch_attachment_records)
+        touch_option = ActiveStorage.touch_attachment_records
+        ActiveStorage.touch_attachment_records = false
+        example.run
+        ActiveStorage.touch_attachment_records = touch_option
+      end
+    end
+
     it 'creates the entity with the attached file', :aggregate_failures do
       expect { test_post.save! }.to change(ActiveStorageDB::File, :count).by(1)
 

--- a/spec/integration/attachments_spec.rb
+++ b/spec/integration/attachments_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Attachments' do
     end
     let(:test_post) { Post.new(title: 'A test post', some_file: uploaded_file) }
 
-    it 'creates the entity with the attached file', :aggregate_failures, :skip_bullet do
+    it 'creates the entity with the attached file', :aggregate_failures do
       expect { test_post.save! }.to change(ActiveStorageDB::File, :count).by(1)
 
       expect(test_post.some_file).to be_attached


### PR DESCRIPTION
_spec/integration/attachments_spec.rb:15_

```
     Bullet::Notification::UnoptimizedQueryError:
       user: runner
        
       AVOID eager loading detected
         ActiveStorage::Attachment => [:record]
         Remove from your query: .includes([:record])
```

---

Explanation here: https://github.com/blocknotes/active_storage_db/issues/69#issuecomment-2926898958